### PR TITLE
Workaround missing parameters from job schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this module will be documented in this file.
  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.3] - 2023-12-07
+
+### Added
+ 
+### Changed
+ 
+### Removed
+
+### Fixed
+ - Parameters disappearing from the job schedule on updates of the runbook
  
 ## [2.0.2] - 2023-08-08
  

--- a/resourcegraph.tf
+++ b/resourcegraph.tf
@@ -61,6 +61,7 @@ resource "azurerm_automation_schedule" "daily" {
   start_time              = time_static.automation_schedule_tomorrow_5am.rfc3339
 }
 
+# Will allways be recreated to fix: https://github.com/hashicorp/terraform-provider-azurerm/issues/17970
 resource "azurerm_automation_job_schedule" "resourcegraph_query" {
   resource_group_name     = var.automation_account.resource_group_name
   automation_account_name = var.automation_account.name

--- a/resourcegraph.tf
+++ b/resourcegraph.tf
@@ -73,5 +73,9 @@ resource "azurerm_automation_job_schedule" "resourcegraph_query" {
     logtype                  = "MonitoringResources"
     customerid               = var.log_analytics_workspace.workspace_id
   }
+
+  lifecycle {
+    replace_triggered_by = [azurerm_automation_runbook.resourcegraph_query]
+  }
 }
 


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

When updating the automation runbook in any way azurerm will allways destroy/create the job schedule: https://github.com/hashicorp/terraform-provider-azurerm/blob/12ea051565bbcd42ec68d6260a42d8961feb84e8/internal/services/automation/automation_runbook_resource.go#L329C1-L356C3

This will ignore any previous parameters on that schedule. To make sure they are not ignored this PR forces the replacement of the job schedule resource when updating the runbook.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `2.0.2`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `2.0.3`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Tested in test environment PCMS DEV1

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
