### PR TITLE
Feature/vm backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
  
 ### Changed
  - Naming of existing rules
+ - Schedule of Resource Graph query to twice daily as intended
    
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to this module will be documented in this file.
  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+ 
+## [2.1.0] - 2023-12-08
+ 
+### Added
+ - New alert rule for failed VM backup jobs
+ 
+### Changed
+ - Naming of existing rules
+   
+### Removed
+
+### Fixed
  
 ## [2.0.2] - 2023-08-08
  

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ AddonAzureBackupJobs
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.7.0 |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ No outputs.
 | [azurerm_automation_module.az_accounts](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_module) | resource |
 | [azurerm_automation_module.az_resourcegraph](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_module) | resource |
 | [azurerm_automation_runbook.resourcegraph_query](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_runbook) | resource |
-| [azurerm_automation_schedule.daily](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_schedule) | resource |
+| [azurerm_automation_schedule.twice_daily](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_schedule) | resource |
 | [azurerm_automation_variable_string.law_sharedkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_variable_string) | resource |
 | [time_static.automation_schedule_tomorrow_5am](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -42,7 +42,7 @@ locals {
         "alr-prd-VMBackup-bkp-law-log-warn-01": {
             description = "Alert when a VM backup job fails"
             query_path  = "${local.path}/vm_backup.kusto"
-            time_window = 
+            time_window = 2280
         }
     }, var.additional_queries)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -2,44 +2,44 @@ locals {
     path = "${path.module}/queries"
 
     rules = merge({
-        "alr-prd-Heartbeat-ux-law-log-crit-01": {
+        "alr-prd-Heartbeat-ux-law-metric-crit-01": {
             description = "Alert when Heartbeat of unix machines Stopped"
             query_path  = "${local.path}/unix_heartbeat.kusto"
             time_window = 2280
         }
-        "alr-prd-Diskspace-ux-law-log-warn-crit-01": {
+        "alr-prd-Diskspace-ux-law-metric-warn-crit-01": {
             description = "Alert when filesystem of unix runs out of space"
             query_path  = "${local.path}/unix_filespace.kusto"
             time_window = 2280
         }
-        "alr-prd-Diskspace-ux-law-log-warn-crit-02": {
+        "alr-prd-Diskspace-ux-law-metric-warn-crit-02": {
             description = "Alert when SAP Filespace runs out of space"
             query_path = "${local.path}/unix_sap_filespace.kusto"
             time_window = 2280
         }
 
-        "alr-prd-Eventlog6008-win-law-log-crit-01": {
+        "alr-prd-Eventlog6008-win-law-logsea-crit-01": {
             description = "Alert when the Windows event 6008 (unexpected shutdown) was logged"
             query_path  = "${local.path}/windows_event_6008.kusto"
             time_window = 30
         }
-        "alr-prd-Eventlog55-win-law-log-crit-01": {
+        "alr-prd-Eventlog55-win-law-logsea-crit-01": {
             description = "Alert when the Windows event 55 (disk corruption) was logged"
             query_path  = "${local.path}/windows_event_55.kusto"
             time_window = 30
         }
 
-        "alr-prd-Heartbeat-win-law-log-crit-01": {
+        "alr-prd-Heartbeat-win-law-metric-crit-01": {
             description = "Alert when Heartbeat from Windows machines Stopped"
             query_path  = "${local.path}/windows_heartbeat.kusto"
             time_window = 2280
         }
-        "alr-prd-Diskspace-win-law-log-warn-crit-01": {
+        "alr-prd-Diskspace-win-law-metric-warn-crit-01": {
             description = "Alert when filesystem of windows runs out of space"
             query_path  = "${local.path}/windows_filespace.kusto"
             time_window = 2280
         }
-        "alr-prd-VMBackup-bkp-law-log-warn-01": {
+        "alr-prd-VMBackup-bkp-law-logsea-warn-01": {
             description = "Alert when a VM backup job fails"
             query_path  = "${local.path}/vm_backup.kusto"
             time_window = 2280

--- a/locals.tf
+++ b/locals.tf
@@ -2,42 +2,47 @@ locals {
     path = "${path.module}/queries"
 
     rules = merge({
-        "alr-prd-heartbeat-ux-law-perf-crit-01": {
+        "alr-prd-Heartbeat-ux-law-log-crit-01": {
             description = "Alert when Heartbeat of unix machines Stopped"
             query_path  = "${local.path}/unix_heartbeat.kusto"
             time_window = 2280
         }
-        "alr-prd-diskspace-ux-law-perf-warn-crit-01": {
+        "alr-prd-Diskspace-ux-law-log-warn-crit-01": {
             description = "Alert when filesystem of unix runs out of space"
             query_path  = "${local.path}/unix_filespace.kusto"
             time_window = 2280
         }
-        "alr-prd-diskspace-ux-law-perf-warn-crit-02": {
+        "alr-prd-Diskspace-ux-law-log-warn-crit-02": {
             description = "Alert when SAP Filespace runs out of space"
             query_path = "${local.path}/unix_sap_filespace.kusto"
             time_window = 2280
         }
 
-        "alr-prd-eventlog6008-win-law-event-crit-01": {
+        "alr-prd-Eventlog6008-win-law-log-crit-01": {
             description = "Alert when the Windows event 6008 (unexpected shutdown) was logged"
             query_path  = "${local.path}/windows_event_6008.kusto"
             time_window = 30
         }
-        "alr-prd-eventlog55-win-law-event-crit-01": {
+        "alr-prd-Eventlog55-win-law-log-crit-01": {
             description = "Alert when the Windows event 55 (disk corruption) was logged"
             query_path  = "${local.path}/windows_event_55.kusto"
             time_window = 30
         }
 
-        "alr-prd-heartbeat-win-law-perf-crit-01": {
+        "alr-prd-Heartbeat-win-law-log-crit-01": {
             description = "Alert when Heartbeat from Windows machines Stopped"
             query_path  = "${local.path}/windows_heartbeat.kusto"
             time_window = 2280
         }
-        "alr-prd-diskspace-win-law-perf-warn-crit-01": {
+        "alr-prd-Diskspace-win-law-log-warn-crit-01": {
             description = "Alert when filesystem of windows runs out of space"
             query_path  = "${local.path}/windows_filespace.kusto"
             time_window = 2280
+        }
+        "alr-prd-VMBackup-bkp-law-log-warn-01": {
+            description = "Alert when a VM backup job fails"
+            query_path  = "${local.path}/vm_backup.kusto"
+            time_window = 
         }
     }, var.additional_queries)
 }

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -10,7 +10,7 @@ AddonAzureBackupJobs
 | extend vault = extract("(microsoft.recoveryservices/vaults/)(.+)$", 2, tostring(_ResourceId))
 | project TimeGenerated, JobFailureCode, vm, vault, _ResourceId, JobOperationSubType, JobStartDateTime, BackupItemUniqueId, AdHocOrScheduledJob
 | join kind = leftouter(VMs) on $left.vm == $right.name
-| where managedby == "q.beyond"
+| where managedby =~ "q.beyond"
 | extend state = "Warning"
 | extend monitor_package = iff(osType == "Windows","AZ_SC_ManagedOSWindows","AZ_SC_ManagedOSUnix")
 | extend monitor_name = "AZ_BACKUP_FAILED"

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -1,4 +1,5 @@
 let VMs = MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
 | where type_s == "microsoft.compute/virtualmachines"
 | summarize take_anyif(TimeGenerated, isnotempty(properties_extended_instanceView_osName_s) ) by name_s, tags_managedby_s, properties_storageProfile_osDisk_osType_s, ResourceId
 | project vmResourceID = ResourceId, name = tolower(name_s), managedby = tags_managedby_s, osType = properties_storageProfile_osDisk_osType_s;

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -1,7 +1,7 @@
 let VMs = MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
 | where type_s == "microsoft.compute/virtualmachines"
-| summarize take_anyif(TimeGenerated, isnotempty(properties_extended_instanceView_osName_s) ) by name_s, tags_managedby_s, properties_storageProfile_osDisk_osType_s, ResourceId
+| summarize arg_max(TimeGenerated, *) by name_s
 | project vmResourceID = ResourceId, name = tolower(name_s), managedby = tags_managedby_s, osType = properties_storageProfile_osDisk_osType_s;
 AddonAzureBackupJobs
 | where JobStatus == "Failed"

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -9,6 +9,7 @@ AddonAzureBackupJobs
 | extend vault = extract("(microsoft.recoveryservices/vaults/)(.+)$", 2, tostring(_ResourceId))
 | project TimeGenerated, JobFailureCode, vm, vault, _ResourceId, JobOperationSubType, JobStartDateTime, BackupItemUniqueId, AdHocOrScheduledJob
 | join kind = leftouter(VMs) on $left.vm == $right.name
+| where managedby == "q.beyond"
 | extend state = "Warning"
 | extend monitor_package = iff(osType == "Windows","AZ_SC_ManagedOSWindows","AZ_SC_ManagedOSUnix")
 | extend monitor_name = "AZ_BACKUP_FAILED"

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -6,7 +6,6 @@ AddonAzureBackupJobs
 | where JobStatus == "Failed"
 | where JobOperation =="Backup"
 | extend vm = extract("(iaasvmcontainerv2;.+?;)(.+)", 2, BackupItemUniqueId)
-| where isnotempty(vm)
 | extend vault = extract("(microsoft.recoveryservices/vaults/)(.+)$", 2, tostring(_ResourceId))
 | project TimeGenerated, JobFailureCode, vm, vault, _ResourceId, JobOperationSubType, JobStartDateTime, BackupItemUniqueId, AdHocOrScheduledJob
 | join kind = leftouter(VMs) on $left.vm == $right.name

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -1,0 +1,23 @@
+let VMs = MonitoringResources_CL 
+| where type_s == "microsoft.compute/virtualmachines"
+| summarize take_anyif(TimeGenerated, isnotempty(properties_extended_instanceView_osName_s) ) by name_s, tags_managedby_s, properties_storageProfile_osDisk_osType_s, ResourceId
+| project vmResourceID = ResourceId, name = tolower(name_s), managedby = tags_managedby_s, osType = properties_storageProfile_osDisk_osType_s;
+AddonAzureBackupJobs
+| where JobStatus == "Failed"
+| where JobOperation =="Backup"
+| extend vm = extract("(iaasvmcontainerv2;.+?;)(.+)", 2, BackupItemUniqueId)
+| where isnotempty(vm)
+| extend vault = extract("(microsoft.recoveryservices/vaults/)(.+)$", 2, tostring(_ResourceId))
+| project TimeGenerated, JobFailureCode, vm, vault, _ResourceId, JobOperationSubType, JobStartDateTime, BackupItemUniqueId, AdHocOrScheduledJob
+| join kind = leftouter(VMs) on $left.vm == $right.name
+| extend state = "Warning"
+| extend monitor_package = iff(osType == "Windows","AZ_SC_ManagedOSWindows","AZ_SC_ManagedOSUnix")
+| extend monitor_name = "AZ_BACKUP_FAILED"
+| extend monitor_description = "Monitors data backup onAzure"
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend threshold = "n/a"
+| extend affected_entity = iff(isempty(JobOperationSubType), "Backup failed on JobOperationSubtype: not given", strcat("Backup failed on JobOperationSubtype: ", JobOperationSubType))
+| extend additional_information = strcat("Backup failed on ",vm,". AdHoc or Scheduled job: " , AdHocOrScheduledJob, ". JobStartDateTime[UTC]: ",JobStartDateTime, ". BackupItemUniqueId: ", BackupItemUniqueId, ". ManagedBy: ",managedby)
+| extend Timestamp = now()
+| project Timestamp, _ResourceId = vmResourceID,state, affected_object = vm, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value = JobFailureCode, affected_entity, additional_information

--- a/resourcegraph.tf
+++ b/resourcegraph.tf
@@ -45,14 +45,14 @@ resource "time_static" "automation_schedule_tomorrow_5am" {
     aac_name  = var.automation_account.name
     aac_id    = var.automation_account.id
     rg_name   = var.automation_account.resource_group_name
-    frequency = "Day"
-    interval  = 1
+    frequency = "Hour"
+    interval  = 12
     timezone  = "Europe/Berlin"
   }
 }
 
-resource "azurerm_automation_schedule" "daily" {
-  name                    = "aas-Import-ResourceGraphToLogAnalytics-Once-Daily"
+resource "azurerm_automation_schedule" "twice_daily" {
+  name                    = "aas-Import-ResourceGraphToLogAnalytics-Twice-Daily"
   resource_group_name     = var.automation_account.resource_group_name
   automation_account_name = var.automation_account.name
   frequency               = time_static.automation_schedule_tomorrow_5am.triggers.frequency
@@ -65,7 +65,7 @@ resource "azurerm_automation_schedule" "daily" {
 resource "azurerm_automation_job_schedule" "resourcegraph_query" {
   resource_group_name     = var.automation_account.resource_group_name
   automation_account_name = var.automation_account.name
-  schedule_name           = azurerm_automation_schedule.daily.name
+  schedule_name           = azurerm_automation_schedule.twice_daily.name
   runbook_name            = azurerm_automation_runbook.resourcegraph_query.name
 
   parameters = {
@@ -79,4 +79,3 @@ resource "azurerm_automation_job_schedule" "resourcegraph_query" {
     replace_triggered_by = [azurerm_automation_runbook.resourcegraph_query]
   }
 }
-

--- a/terraform.tf
+++ b/terraform.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 3.7.0"
     }
   }
-required_version = ">=1.1.0"
+required_version = ">=1.5.0"
 }


### PR DESCRIPTION
# Description

Added a new query for alerting on failed VM backup jobs of the RSV.

Also fixed the naming of alert rules according to our naming convention. 
This will redeploy the alert rules. 
In most cases this would be a breaking change, but here I think it's fine for alert rules to be redeployed.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `3.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `3.1.0`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Tested query with specified time window

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation
- [x] I have updated the CHANGELOG
