### PR TITLE
Update unix_heartbeat.kusto

### DIFF
--- a/queries/unix_filespace.kusto
+++ b/queries/unix_filespace.kusto
@@ -1,21 +1,34 @@
 // more or equal than 90% Diskspace used (Unix)
-let mountpoints = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup"]);
+let mountpoints = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup", "/boot/efi"]);
 let warning = int(80);
 let critical = int(90);
 Perf
-    | where ObjectName contains "Logical Disk"
-    | where CounterName == "% Used Space"
-    | where InstanceName in (mountpoints)
-    | where CounterValue >= (warning)
-    | where TimeGenerated > ago(5m)
-    | extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
-    | extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
-    | extend monitor_package = "AZ_UX_SC_ManagedOSUnix"
-    | extend monitor_name = "AZ_UNIX_FILESPACE"
-    | extend monitor_description = strcat("Disk threshold reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend value = round(CounterValue, 2)
-    | extend additional_information = strcat("more or equal than ", (threshold), "% Diskspace used (Unix)")
-    | extend affected_entity = InstanceName
-    | project TimeGenerated, _ResourceId, state, affected_object = Computer, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+| where ObjectName contains "Logical Disk"
+| where CounterName == "% Used Space"
+| where InstanceName in (mountpoints)
+| where CounterValue >= (warning)
+| where TimeGenerated > ago(5m)
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| summarize arg_max(TimeGenerated, *) by affected_object, InstanceName
+| extend _ResourceId = toupper(_ResourceId)
+| project _ResourceId, affected_object, CounterValue, InstanceName
+| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
+| extend id_s = toupper(id_s)
+| project TimeGenerated,MonitoringResources, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by MonitoringResources)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
+| where CounterValue >= (warning)
+| extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
+| extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
+| extend monitor_package = "AZ_UX_SC_ManagedOSUnix"
+| extend monitor_name = "AZ_UNIX_FILESPACE"
+| extend monitor_description = strcat("Disk threshold has been reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend value = round(CounterValue, 2)
+| extend additional_information = strcat("more or equal than ", (threshold), "% Diskspace used. Managed by ",(tags_managedby_s),".")
+| extend affected_entity = InstanceName
+| project TimeGenerated =now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/unix_filespace.kusto
+++ b/queries/unix_filespace.kusto
@@ -1,4 +1,10 @@
 // more or equal than 90% Diskspace used (Unix)
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 let mountpoints = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup", "/boot/efi"]);
 let warning = int(80);
 let critical = int(90);
@@ -12,12 +18,7 @@ Perf
 | summarize arg_max(TimeGenerated, *) by affected_object, InstanceName
 | extend _ResourceId = toupper(_ResourceId)
 | project _ResourceId, affected_object, CounterValue, InstanceName
-| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
-| extend id_s = toupper(id_s)
-| project TimeGenerated,MonitoringResources, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by MonitoringResources)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
 | where CounterValue >= (warning)

--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -1,17 +1,18 @@
 // Track VM availability 
 // Display the VM's reported availability during the last 5 minutes.
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 Heartbeat
 | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
 | summarize LH = arg_max(TimeGenerated, *) by affected_object
 | where LH < ago(5m)
 | extend _ResourceId = toupper(_ResourceId)
 | project _ResourceId, affected_object, OSType, LH
-| join kind= leftouter (MonitoringResources_CL 
-| where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend id_s = toupper(id_s)
-| project TimeGenerated, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by id_s)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
 | where OSType contains_cs "Linux"

--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -2,16 +2,18 @@
 // Display the VM's reported availability during the last 5 minutes.
 Heartbeat
 | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| summarize LH = arg_max(TimeGenerated, *) by affected_object
+| where LH < ago(5m)
+| extend _ResourceId = toupper(_ResourceId)
+| project _ResourceId, affected_object, OSType, LH
 | join kind= leftouter (MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
 | where type_s == "microsoft.compute/virtualmachines" 
-| extend vm_MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
-| project TimeGenerated,vm_MonitoringResources, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by vm_MonitoringResources)
-on $left.affected_object == $right.vm_MonitoringResources
-| where tolower(tags_managedby_s) == "q.beyond"
-| summarize LH = arg_max(TimeGenerated, *) by affected_object
-| where LH < ago(5m)
+| extend id_s = toupper(id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by id_s)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
 | where OSType contains_cs "Linux"
 | extend monitor_package = "AZ_UNIX_BASEPOLICY"
 | extend monitor_name = "AZ_UNIX_HEARTBEAT"
@@ -22,4 +24,4 @@ on $left.affected_object == $right.vm_MonitoringResources
 | extend value = LH
 | extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
 | extend additional_information = strcat("The Host did not send Heartbeats anymore. Managed by ",(tags_managedby_s),".")
-| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=affected_object, additional_information

--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -2,6 +2,14 @@
 // Display the VM's reported availability during the last 5 minutes.
 Heartbeat
 | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| join kind= leftouter (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend vm_MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
+| project TimeGenerated,vm_MonitoringResources, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by vm_MonitoringResources)
+on $left.affected_object == $right.vm_MonitoringResources
+| where tolower(tags_managedby_s) == "q.beyond"
 | summarize LH = arg_max(TimeGenerated, *) by affected_object
 | where LH < ago(5m)
 | where OSType contains_cs "Linux"
@@ -13,6 +21,5 @@ Heartbeat
 | extend threshold = "00:05:00"
 | extend value = LH
 | extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
-| extend additional_information = "The Host did not send Heartbeats anymore."
+| extend additional_information = strcat("The Host did not send Heartbeats anymore. Managed by ",(tags_managedby_s),".")
 | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
-

--- a/queries/unix_sap_filespace.kusto
+++ b/queries/unix_sap_filespace.kusto
@@ -1,50 +1,51 @@
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 let mountpoints = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup"]);
-      let warning = int(90);
-      let critical = int(95);
-      let d1='{"volumes": [{"mountpoint":"/SAPINST$","warning":90,"critical":"95"}]}';
-      let d2='{"volumes": [{"mountpoint":"^/hana/log/[A-Za-z0-9]{3}","warning":50,"critical":"70"}]}';
-      let d3='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/oraarch$","warning":50,"critical":"70"}]}';
-      let d4='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/(orig|mirr)log[A-B]$","warning":90,"critical":"95"}]}';
-      let d5='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/sapdata","warning":90,"critical":"95"}]}';
-      //let d6='{"volumes": [{"mountpoint":"xxx$","warning":xx,"critical":"xx"}]}';
-      Perf
-      | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
-      | where ObjectName contains "Logical Disk"
-      | where CounterName == "% Used Space"
-      | where InstanceName matches regex "/.*"
-      | where InstanceName !in (mountpoints)
-      | where TimeGenerated > ago(5m)
-      | where CounterValue >= (warning)
-      | extend _ResourceId = toupper(_ResourceId)
-      | extend VolumeName = InstanceName
-      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].warning), tostring(warning))
-      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].critical), tostring(critical))
-      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].warning), tostring(warning))
-      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].critical), tostring(critical))
-      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].warning), tostring(warning))
-      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].critical), tostring(critical))
-      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].warning), tostring(warning))
-      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].critical), tostring(critical))
-      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].warning), tostring(warning))
-      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].critical), tostring(critical))
-      | extend warning = toint(warning)
-      | extend critical = toint(critical)
-      | join kind= leftouter (MonitoringResources_CL 
-      | where TimeGenerated > ago(13h)
-      | where type_s == "microsoft.compute/virtualmachines"
-      | extend id_s = toupper(id_s) 
-      | project TimeGenerated, id_s, tags_managedby_s
-      | summarize arg_max(TimeGenerated,*) by id_s)
-      on $left._ResourceId == $right.id_s
-      | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
-      | extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
-      | extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
-      | extend monitor_package = "AZ_SC_ManagedSAPInstance"
-      | extend monitor_name = "AZ_UNIX_FILESPACE"
-      | extend monitor_description = strcat("Disk threshold reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
-      | extend script_name = "n/a"
-      | extend script_version = "n/a"
-      | extend value = round(CounterValue, 2)
-      | extend additional_information = strcat("More or equal than ", (threshold), "% Diskspace used (Unix). Managed by: ",(tags_managedby_s),".")
-      | extend affected_entity = InstanceName
-      | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+let warning = int(90);
+let critical = int(95);
+let d1='{"volumes": [{"mountpoint":"/SAPINST$","warning":90,"critical":"95"}]}';
+let d2='{"volumes": [{"mountpoint":"^/hana/log/[A-Za-z0-9]{3}","warning":50,"critical":"70"}]}';
+let d3='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/oraarch$","warning":50,"critical":"70"}]}';
+let d4='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/(orig|mirr)log[A-B]$","warning":90,"critical":"95"}]}';
+let d5='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/sapdata","warning":90,"critical":"95"}]}';
+//let d6='{"volumes": [{"mountpoint":"xxx$","warning":xx,"critical":"xx"}]}';
+Perf
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| where ObjectName contains "Logical Disk"
+| where CounterName == "% Used Space"
+| where InstanceName matches regex "/.*"
+| where InstanceName !in (mountpoints)
+| where TimeGenerated > ago(5m)
+| where CounterValue >= (warning)
+| extend _ResourceId = toupper(_ResourceId)
+| extend VolumeName = InstanceName
+| extend warning = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].warning), tostring(warning))
+| extend critical = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].critical), tostring(critical))
+| extend warning = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].warning), tostring(warning))
+| extend critical = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].critical), tostring(critical))
+| extend warning = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].warning), tostring(warning))
+| extend critical = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].critical), tostring(critical))
+| extend warning = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].warning), tostring(warning))
+| extend critical = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].critical), tostring(critical))
+| extend warning = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].warning), tostring(warning))
+| extend critical = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].critical), tostring(critical))
+| extend warning = toint(warning)
+| extend critical = toint(critical)
+| join kind= leftouter VMs
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
+| extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
+| extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
+| extend monitor_package = "AZ_SC_ManagedSAPInstance"
+| extend monitor_name = "AZ_UNIX_FILESPACE"
+| extend monitor_description = strcat("Disk threshold reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend value = round(CounterValue, 2)
+| extend additional_information = strcat("More or equal than ", (threshold), "% Diskspace used (Unix). Managed by: ",(tags_managedby_s),".")
+| extend affected_entity = InstanceName
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/unix_sap_filespace.kusto
+++ b/queries/unix_sap_filespace.kusto
@@ -1,40 +1,50 @@
 let mountpoints = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup"]);
-let warning = int(90);
-let critical = int(95);
-let d1='{"volumes": [{"mountpoint":"/SAPINST$","warning":90,"critical":"95"}]}';
-let d2='{"volumes": [{"mountpoint":"^/hana/log/[A-Za-z0-9]{3}","warning":50,"critical":"70"}]}';
-let d3='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/oraarch$","warning":50,"critical":"70"}]}';
-let d4='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/(orig|mirr)log[A-B]$","warning":90,"critical":"95"}]}';
-let d5='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/sapdata","warning":90,"critical":"95"}]}';
-//let d6='{"volumes": [{"mountpoint":"xxx$","warning":xx,"critical":"xx"}]}';
-Perf
-    | where ObjectName contains "Logical Disk"
-    | where CounterName == "% Used Space"
-    | where InstanceName matches regex "/.*"
-    | where InstanceName !in (mountpoints)
-    | where TimeGenerated > ago(5m)
-    | extend VolumeName = InstanceName
-    | extend warning = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].warning), tostring(warning))
-    | extend critical = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].critical), tostring(critical))
-    | extend warning = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].warning), tostring(warning))
-    | extend critical = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].critical), tostring(critical))
-    | extend warning = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].warning), tostring(warning))
-    | extend critical = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].critical), tostring(critical))
-    | extend warning = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].warning), tostring(warning))
-    | extend critical = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].critical), tostring(critical))
-    | extend warning = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].warning), tostring(warning))
-    | extend critical = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].critical), tostring(critical))
-    | extend warning = toint(warning)
-    | extend critical = toint(critical)
-    | where CounterValue >= (warning)
-    | extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
-    | extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
-    | extend monitor_package = "AZ_SC_ManagedSAPInstance"
-    | extend monitor_name = "AZ_UNIX_FILESPACE"
-    | extend monitor_description = strcat("Disk threshold reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend value = round(CounterValue, 2)
-    | extend additional_information = strcat("more or equal than ", (threshold), "% Diskspace used (Unix)")
-    | extend affected_entity = InstanceName
-    | project TimeGenerated, _ResourceId, state, affected_object = Computer, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+      let warning = int(90);
+      let critical = int(95);
+      let d1='{"volumes": [{"mountpoint":"/SAPINST$","warning":90,"critical":"95"}]}';
+      let d2='{"volumes": [{"mountpoint":"^/hana/log/[A-Za-z0-9]{3}","warning":50,"critical":"70"}]}';
+      let d3='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/oraarch$","warning":50,"critical":"70"}]}';
+      let d4='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/(orig|mirr)log[A-B]$","warning":90,"critical":"95"}]}';
+      let d5='{"volumes": [{"mountpoint":"^/oracle/[A-Za-z0-9]{3}/sapdata","warning":90,"critical":"95"}]}';
+      //let d6='{"volumes": [{"mountpoint":"xxx$","warning":xx,"critical":"xx"}]}';
+      Perf
+      | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+      | where ObjectName contains "Logical Disk"
+      | where CounterName == "% Used Space"
+      | where InstanceName matches regex "/.*"
+      | where InstanceName !in (mountpoints)
+      | where TimeGenerated > ago(5m)
+      | where CounterValue >= (warning)
+      | extend _ResourceId = toupper(_ResourceId)
+      | extend VolumeName = InstanceName
+      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].warning), tostring(warning))
+      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d1).volumes[0].mountpoint)), tostring(parse_json(d1).volumes[0].critical), tostring(critical))
+      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].warning), tostring(warning))
+      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d2).volumes[0].mountpoint)), tostring(parse_json(d2).volumes[0].critical), tostring(critical))
+      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].warning), tostring(warning))
+      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d3).volumes[0].mountpoint)), tostring(parse_json(d3).volumes[0].critical), tostring(critical))
+      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].warning), tostring(warning))
+      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d4).volumes[0].mountpoint)), tostring(parse_json(d4).volumes[0].critical), tostring(critical))
+      | extend warning = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].warning), tostring(warning))
+      | extend critical = iff(InstanceName matches regex (tostring(parse_json(d5).volumes[0].mountpoint)), tostring(parse_json(d5).volumes[0].critical), tostring(critical))
+      | extend warning = toint(warning)
+      | extend critical = toint(critical)
+      | join kind= leftouter (MonitoringResources_CL 
+      | where TimeGenerated > ago(13h)
+      | where type_s == "microsoft.compute/virtualmachines"
+      | extend id_s = toupper(id_s) 
+      | project TimeGenerated, id_s, tags_managedby_s
+      | summarize arg_max(TimeGenerated,*) by id_s)
+      on $left._ResourceId == $right.id_s
+      | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
+      | extend threshold = case(CounterValue >= (critical), critical, CounterValue < (critical), warning, warning)
+      | extend state = case(CounterValue >= (critical), "Critical", CounterValue <= (critical), "Warning", "")
+      | extend monitor_package = "AZ_SC_ManagedSAPInstance"
+      | extend monitor_name = "AZ_UNIX_FILESPACE"
+      | extend monitor_description = strcat("Disk threshold reached. More or equal than ", (threshold), "% Diskspace used. Check the Diskspace of the Mountpoint, please.")
+      | extend script_name = "n/a"
+      | extend script_version = "n/a"
+      | extend value = round(CounterValue, 2)
+      | extend additional_information = strcat("More or equal than ", (threshold), "% Diskspace used (Unix). Managed by: ",(tags_managedby_s),".")
+      | extend affected_entity = InstanceName
+      | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/windows_event_55.kusto
+++ b/queries/windows_event_55.kusto
@@ -2,18 +2,31 @@
 let WinEventLog = "System";
 let WinSource = "Ntfs";
 let WinEventID = 55;
+let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups
 Event
-    | where EventLog == WinEventLog and WinSource == WinSource and EventID == WinEventID
-    | extend vm = toupper(tostring(split(_ResourceId, "/") [-1]))
-    | extend state = "Critical"
-    | extend affected_object = vm
-    | extend monitor_package = "AZ_SC_ManagedOSWindows"
-    | extend monitor_name = "AZ_NT_EVENTLOG_55"
-    | extend monitor_description = "Search the Windows event log for specific entries."
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend threshold = "n/a"
-    | extend value = "n/a"
-    | extend affected_entity = vm
-    | extend additional_information = strcat("Windows log entry has been found. EventLogType: ", EventLog, "; Source: ", Source, "; EventID: ", EventID, "; Description: ", RenderedDescription, "; Check the System, please." )
-    | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+| where EventLog == WinEventLog and Source == WinSource and EventID == WinEventID
+| where TimeGenerated > ago(10m)
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| extend affected_groups = toupper(extract(@"/resourcegroups/(.+)/providers", 1, _ResourceId)) // find groups
+| where not(affected_groups matches regex appl_groups)
+| extend _ResourceId = toupper(_ResourceId)
+| summarize arg_max(TimeGenerated, *) by affected_object
+| project _ResourceId, affected_object, EventLog, Source, EventID, RenderedDescription
+| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend id_s = toupper(id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by id_s)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
+| extend state = "Critical"
+| extend monitor_package = "AZ_SC_ManagedOSWindows"
+| extend monitor_name = "AZ_NT_EVENTLOG_55"
+| extend monitor_description = "Search the Windows event log for specific entries."
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend threshold = "n/a"
+| extend value = "n/a"
+| extend affected_entity = affected_object
+| extend additional_information = strcat("Windows log entry has been found. EventLogType: ", EventLog, "; Source: ", Source, "; EventID: ", EventID, "; Description: ", RenderedDescription, "; Check the System, please. Managed by: ",(tags_managedby_s),"." )
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/windows_event_55.kusto
+++ b/queries/windows_event_55.kusto
@@ -1,4 +1,10 @@
 //Search the Windows event log for specific entries.
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 let WinEventLog = "System";
 let WinSource = "Ntfs";
 let WinEventID = 55;
@@ -12,11 +18,7 @@ Event
 | extend _ResourceId = toupper(_ResourceId)
 | summarize arg_max(TimeGenerated, *) by affected_object
 | project _ResourceId, affected_object, EventLog, Source, EventID, RenderedDescription
-| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend id_s = toupper(id_s)
-| project TimeGenerated, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by id_s)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
 | extend state = "Critical"

--- a/queries/windows_event_6008.kusto
+++ b/queries/windows_event_6008.kusto
@@ -1,7 +1,13 @@
 //Search the Windows event log for specific entries.
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 let WinEventLog = "System";
 let WinSource = "EventLog";
-let WinEventID = 6008;
+let WinEventID = "6008";
 let appl_groups = ("RG.*AV*");  // excluding a list of ResourceGroups
 Event
 | where EventLog == WinEventLog and Source == WinSource and EventID == WinEventID
@@ -12,11 +18,7 @@ Event
 | extend _ResourceId = toupper(_ResourceId)
 | summarize arg_max(TimeGenerated, *) by affected_object
 | project _ResourceId, affected_object, EventLog, Source, EventID, RenderedDescription
-| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend id_s = toupper(id_s)
-| project TimeGenerated, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by id_s)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
 | extend state = "Critical"

--- a/queries/windows_event_6008.kusto
+++ b/queries/windows_event_6008.kusto
@@ -2,18 +2,31 @@
 let WinEventLog = "System";
 let WinSource = "EventLog";
 let WinEventID = 6008;
+let appl_groups = ("RG.*AV*");  // excluding a list of ResourceGroups
 Event
-    | where EventLog == WinEventLog and Source == WinSource and EventID == WinEventID
-    | extend vm = toupper(tostring(split(_ResourceId, "/") [-1]))
-    | extend state = "Critical"
-    | extend affected_object = vm
-    | extend monitor_package = "AZ_SC_ManagedOSWindows"
-    | extend monitor_name = "AZ_NT_EVENTLOG_6008"
-    | extend monitor_description = "Search the Windows event log for specific entries."
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend threshold = "n/a"
-    | extend value = "n/a"
-    | extend affected_entity = vm
-    | extend additional_information = strcat("Windows log entry has been found. EventLogType: ", EventLog, "; Source: ", Source, "; EventID: ", EventID, "; Description: ", RenderedDescription, "; Check the System, please." )
-    | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+| where EventLog == WinEventLog and Source == WinSource and EventID == WinEventID
+| where TimeGenerated > ago(10m)
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| extend affected_groups = toupper(extract(@"/resourcegroups/(.+)/providers", 1, _ResourceId)) // find groups
+| where not(affected_groups matches regex appl_groups)
+| extend _ResourceId = toupper(_ResourceId)
+| summarize arg_max(TimeGenerated, *) by affected_object
+| project _ResourceId, affected_object, EventLog, Source, EventID, RenderedDescription
+| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend id_s = toupper(id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by id_s)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s)
+| extend state = "Critical"
+| extend monitor_package = "AZ_SC_ManagedOSWindows"
+| extend monitor_name = "AZ_NT_EVENTLOG_6008"
+| extend monitor_description = "Search the Windows event log for specific entries."
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend threshold = "n/a"
+| extend value = "n/a"
+| extend affected_entity = affected_object
+| extend additional_information = strcat("Windows log entry has been found. EventLogType: ", EventLog, "; Source: ", Source, "; EventID: ", EventID, "; Description: ", RenderedDescription, "; Check the System, please. Managed by: ",(tags_managedby_s),"." )
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/windows_event_6008.kusto
+++ b/queries/windows_event_6008.kusto
@@ -8,7 +8,7 @@ let VMs = (MonitoringResources_CL
 let WinEventLog = "System";
 let WinSource = "EventLog";
 let WinEventID = "6008";
-let appl_groups = ("RG.*AV*");  // excluding a list of ResourceGroups
+let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups
 Event
 | where EventLog == WinEventLog and Source == WinSource and EventID == WinEventID
 | where TimeGenerated > ago(10m)

--- a/queries/windows_filespace.kusto
+++ b/queries/windows_filespace.kusto
@@ -1,4 +1,10 @@
 // less or equal than 10% Diskspace free (Windows)
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
 let Disks = dynamic(["C:"]);
 let warning = int(10);
 let critical = int(5);
@@ -17,12 +23,7 @@ Perf
 | where not(affected_groups matches regex appl_groups)
 | summarize arg_max(TimeGenerated, *) by affected_object, InstanceName
 | project _ResourceId, affected_groups, affected_object, CounterValue, threshold, InstanceName, state
-| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
-| extend id_s = toupper(id_s)
-| project TimeGenerated,MonitoringResources, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by MonitoringResources)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
 | extend monitor_package = "AZ_NT_BASEPOLICY"

--- a/queries/windows_filespace.kusto
+++ b/queries/windows_filespace.kusto
@@ -1,21 +1,36 @@
-// Disk threshold reached. Less or equal than warning or critical diskspace free (%). (Windows Monitoring)
+// less or equal than 10% Diskspace free (Windows)
 let Disks = dynamic(["C:"]);
 let warning = int(10);
 let critical = int(5);
+let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups
 Perf
-    | where ObjectName contains "LogicalDisk"
-    | where CounterName == "% Free Space"
-    | where InstanceName in (Disks)
-    | where CounterValue <= (warning)
-    | where TimeGenerated > ago(5m)
-    | extend state = case(CounterValue >= (critical), "Warning", CounterValue <= (critical), "Critical", "Warning")
-    | extend threshold = case(CounterValue >= (critical), warning, CounterValue <= (critical), critical, warning)
-    | extend monitor_package = "AZ_NT_BASEPOLICY"
-    | extend monitor_name = "AZ_NT_DISKS"
-    | extend monitor_description = strcat("Disk threshold reached. Less or equal than ", (threshold), "% Diskspace free. Please, check the Diskspace")
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend value = round(CounterValue, 2)
-    | extend additional_information = strcat("Only ", (value), " % Diskspace free.")
-    | extend affected_entity = InstanceName
-    | project TimeGenerated, _ResourceId, state, affected_object = Computer, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information
+| where TimeGenerated > ago(5m)
+| where ObjectName contains "LogicalDisk"
+| where CounterName == "% Free Space"
+| where InstanceName in (Disks)
+| where CounterValue <= (warning)
+| extend state = case(CounterValue >= (critical), "Warning", CounterValue <= (critical), "Critical", "Warning")
+| extend threshold = case(CounterValue >= (critical), warning, CounterValue <= (critical), critical, warning)
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| extend affected_groups = toupper(extract(@"/resourcegroups/(.+)/providers", 1, _ResourceId)) // find groups
+| extend _ResourceId = toupper(_ResourceId)
+| where not(affected_groups matches regex appl_groups)
+| summarize arg_max(TimeGenerated, *) by affected_object, InstanceName
+| project _ResourceId, affected_groups, affected_object, CounterValue, threshold, InstanceName, state
+| join kind= leftouter (MonitoringResources_CL | where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
+| extend id_s = toupper(id_s)
+| project TimeGenerated,MonitoringResources, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by MonitoringResources)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
+| extend monitor_package = "AZ_NT_BASEPOLICY"
+| extend monitor_name = "AZ_NT_DISKS"
+| extend monitor_description = strcat("Disk threshold has been reached. Less or equal than ", (threshold), "% Diskspace free. Please, check the Diskspace.")
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend value = round(CounterValue, 2)
+| extend additional_information = strcat("Only ", (value), " % Diskspace free. Managed by ",(tags_managedby_s),".")
+| extend affected_entity = InstanceName
+| project TimeGenerated = now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity, additional_information

--- a/queries/windows_heartbeat.kusto
+++ b/queries/windows_heartbeat.kusto
@@ -1,6 +1,12 @@
 // Track VM availability 
 // Display the VM's reported availability during the last 5 minutes.
-let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups
+let VMs = (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines"
+| extend id_s = toupper(id_s) 
+| summarize arg_max(TimeGenerated,*) by id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s;
+let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups. In this case AVD.
 Heartbeat
 | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
 | extend affected_groups = toupper(extract(@"/resourcegroups/(.+)/providers", 1, _ResourceId)) // find groups
@@ -9,12 +15,7 @@ Heartbeat
 | where LH < ago(5m)
 | extend _ResourceId = toupper(_ResourceId)
 | project _ResourceId, affected_groups, affected_object, OSType, LH
-| join kind= leftouter (MonitoringResources_CL 
-| where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines" 
-| extend id_s = toupper(id_s)
-| project TimeGenerated, id_s, name_s, tags_managedby_s
-| summarize arg_max(TimeGenerated,*) by id_s)
+| join kind= leftouter VMs
 on $left._ResourceId == $right.id_s
 | where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
 | where OSType contains_cs "Windows"

--- a/queries/windows_heartbeat.kusto
+++ b/queries/windows_heartbeat.kusto
@@ -1,18 +1,30 @@
 // Track VM availability 
 // Display the VM's reported availability during the last 5 minutes.
+let appl_groups = ("RG.*AVD*");  // excluding a list of ResourceGroups
 Heartbeat
-    | extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
-    | summarize LH = arg_max(TimeGenerated, *) by affected_object
-    | where LH < ago(5m)
-    | where OSType contains_cs "Windows"
-    | extend monitor_package = "AZ_NT_BASEPOLICY"
-    | extend monitor_name = "AZ_NT_HEARTBEAT"
-    | extend monitor_description = "Checks availability of the Host"
-    | extend script_name = "n/a"
-    | extend script_version = "n/a"
-    | extend threshold = "00:05:00"
-    | extend value = LH
-    | extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
-    | extend additional_information = ""
-    | project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=Computer, additional_information
-
+| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
+| extend affected_groups = toupper(extract(@"/resourcegroups/(.+)/providers", 1, _ResourceId)) // find groups
+| where not(affected_groups matches regex appl_groups)
+| summarize LH = arg_max(TimeGenerated, *) by affected_object
+| where LH < ago(5m)
+| extend _ResourceId = toupper(_ResourceId)
+| project _ResourceId, affected_groups, affected_object, OSType, LH
+| join kind= leftouter (MonitoringResources_CL 
+| where TimeGenerated > ago(13h)
+| where type_s == "microsoft.compute/virtualmachines" 
+| extend id_s = toupper(id_s)
+| project TimeGenerated, id_s, name_s, tags_managedby_s
+| summarize arg_max(TimeGenerated,*) by id_s)
+on $left._ResourceId == $right.id_s
+| where tags_managedby_s =~ "q.beyond" or isempty(tags_managedby_s) 
+| where OSType contains_cs "Windows"
+| extend monitor_package = "AZ_NT_BASEPOLICY"
+| extend monitor_name = "AZ_NT_HEARTBEAT"
+| extend monitor_description = "Checks availability of the Host"
+| extend script_name = "n/a"
+| extend script_version = "n/a"
+| extend threshold = "00:05:00"
+| extend value = LH
+| extend state = iff(datetime_diff("second", now(), LH) >= 300, "CRITICAL", "OK")
+| extend additional_information = strcat("The Host did not send Heartbeats anymore. Managed by ",(tags_managedby_s),".")
+| project TimeGenerated=now(), _ResourceId, state, affected_object, monitor_package, monitor_name, monitor_description, script_name, script_version, threshold, value, affected_entity=affected_object, additional_information


### PR DESCRIPTION
Includes the MonitoringResources_CL table (join-function) to take the 'tags_mangedby' tag into consideration.

# Description

Including MonitoringResources_CL table join to take the tags_mangedby tags into consideration.
With this extension, it is now possible to differentiate between provider and customer systems in the context of alerting.

<!-- Example -->
Heartbeat
| extend affected_object = toupper(tostring(split(_ResourceId, "/") [-1]))
| join kind= leftouter (MonitoringResources_CL 
| where type_s == "microsoft.compute/virtualmachines" 
| extend vm_MonitoringResources = toupper(tostring(split(id_s, "/") [-1])) 
| project TimeGenerated,vm_MonitoringResources, id_s, name_s, tags_managedby_s
| summarize arg_max(TimeGenerated,*) by vm_MonitoringResources)
on $left.affected_object == $right.vm_MonitoringResources
| where tolower(tags_managedby_s) == "provider"
| summarize LH = arg_max(TimeGenerated, *) by affected_object
| where LH < ago(5m)



# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [x] This adds a new backward compatible Feature
- [ ] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `3.2.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number --> 
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above):  `3.3.0`

# How Has This Been Tested?

 - The new kusto query has been tested in a customer environment.
 - Used Azure tenant Log Analytics Workspace: law-[tenant]-Management-Managment-01

- [x] Apply of all examples was successfull
- [ ] Test B

# Checklist:

- [x ] I have run tests and documented them above
- [x ] I have performed a self-review of my own code
- [x ] I have updated the documentation
- [x ] I have updated the CHANGELOG
