### PR TITLE
fixed arc query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [4.2.1] - 2024-06-11
+
+### Fixed
+- Fixed Resource-Graph query so tag filtering properly excludes Arc machines
+
 ## [4.2.0] - 2024-04-04
 
 ### Added

--- a/queries/unix_filespace.kusto
+++ b/queries/unix_filespace.kusto
@@ -1,7 +1,7 @@
 // more or equal than 90% Diskspace used (Unix)
 let VMs = MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/queries/unix_heartbeat.kusto
+++ b/queries/unix_heartbeat.kusto
@@ -2,7 +2,7 @@
 // Display the VM's reported availability during the last 5 minutes.
 let VMs = (MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s)
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/queries/unix_sap_filespace.kusto
+++ b/queries/unix_sap_filespace.kusto
@@ -9,7 +9,7 @@ let config = dynamic([
 let excludes = dynamic(["/", "/var", "/boot", "/tmp", "/home", "/opt", "/backup"]);
 let VMs = MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | summarize arg_max(TimeGenerated,*) by id_s
 | project TimeGenerated, vm_resource_id = tolower(id_s), name = name_s, managed_by = tags_managedby_s, alerting = tags_alerting_s;
 InsightsMetrics

--- a/queries/vm_backup.kusto
+++ b/queries/vm_backup.kusto
@@ -1,6 +1,6 @@
 let VMs = MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | summarize arg_max(TimeGenerated, *) by name_s
 | project vmResourceID = ResourceId, name = tolower(name_s), managedby = tags_managedby_s, alerting = tags_alerting_s, osType = properties_storageProfile_osDisk_osType_s;
 AddonAzureBackupJobs

--- a/queries/windows_event_55.kusto
+++ b/queries/windows_event_55.kusto
@@ -1,7 +1,7 @@
 //Search the Windows event log for specific entries.
 let VMs = (MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s)
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/queries/windows_event_6008.kusto
+++ b/queries/windows_event_6008.kusto
@@ -1,7 +1,7 @@
 //Search the Windows event log for specific entries.
 let VMs = (MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s)
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/queries/windows_filespace.kusto
+++ b/queries/windows_filespace.kusto
@@ -1,7 +1,7 @@
 // less or equal than 10% Diskspace free (Windows)
 let VMs = MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/queries/windows_heartbeat.kusto
+++ b/queries/windows_heartbeat.kusto
@@ -2,7 +2,7 @@
 // Display the VM's reported availability during the last 5 minutes.
 let VMs = (MonitoringResources_CL 
 | where TimeGenerated > ago(13h)
-| where type_s == "microsoft.compute/virtualmachines"
+| where type_s in~ ("microsoft.compute/virtualmachines", "microsoft.hybridcompute/machines", "microsoft.compute/virtualmachinescalesets")
 | extend id_s = toupper(id_s) 
 | summarize arg_max(TimeGenerated,*) by id_s)
 | project TimeGenerated, id_s, name_s, tags_managedby_s, tags_alerting_s;

--- a/resourcegraph/resource.kusto
+++ b/resourcegraph/resource.kusto
@@ -12,7 +12,9 @@ resources
 	"microsoft.Sql/managedInstances/databases",
 	"microsoft.Storage/storageaccounts",
 	"microsoft.Compute/virtualmachines",
+	"microsoft.compute/virtualmachinescalesets",
 	"microsoft.Network/virtualWans",
-	"microsoft.Network/vpngateways"
+	"microsoft.Network/vpngateways",
+	"microsoft.hybridcompute/machines"
 )
 | project id, name, type, tenantId, location, resourceGroup, subscriptionId, tags, properties


### PR DESCRIPTION
# Description

Since last version tagging should decide which VMs are monitored.
This was however ignored for Arc VMs which then defaulted to monitoring enabled.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `4.2.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `4.2.1`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- [x] Resource Graph query and Alert rules were tested

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
