### PR TITLE
Feature/backup aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this module adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [6.3.1] - 2025-09-01
+
+### Changed
+
+- Backup alert rule now runs every hour instead of every two days
+
 ## [6.3.0] - 2025-07-29
 
 ### Added

--- a/locals.tf
+++ b/locals.tf
@@ -49,7 +49,7 @@ locals {
       description = "Alert when a backup job fails"
       query_path  = "${local.path}/backup.kusto.tftpl"
       time_window = "P2D"
-      frequency   = "PT5M"
+      frequency   = "PT1H"
     }
     "alr-int-CustLogJson-winux-law-logsea-warn-01" : {
       description    = "Alert for custom json monitoring logs"


### PR DESCRIPTION
# Description

<!-- Please include a summary of changes and which issues are fixed -->
<!-- Example -->

As requested by our monitoring colleagues, the aggregation time of the backup alert rule should be changed to 1h.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `6.3.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `6.3.1`

# How Has This Been Tested?

<!-- Please list and describe tests that you performed -->
<!-- You should always do some tests! -->

- no tests, just one value change that corresponds with tf doku: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert#frequency-1

# Checklist:

- [ ] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [ ] I have updated the documentation
- [x] I have updated the CHANGELOG
